### PR TITLE
change current page on filter change

### DIFF
--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -248,8 +248,9 @@ Template.reactiveTable.events({
 
     "change .reactive-table-filter input": function (event) {
         var filterText = $(event.target).val();
-         var group = $(event.target).parents('.reactive-table-filter').attr('reactive-table-group');
+        var group = $(event.target).parents('.reactive-table-filter').attr('reactive-table-group');
         Session.set(getSessionFilterKey(group), filterText);
+        Session.set(getSessionCurrentPageKey(this.group), 0);
     },
 
     "change .reactive-table-navigation .rows-per-page input": function (event) {


### PR DESCRIPTION
Hi,
when you activate filtering and your current page is greater than the max number page after filtering the result table is empty.  (page 2 of 1)
i'm not sure it's the best behavior but i propose to set current page to the first one when a filter is entered.
cheers,
Cyrille.
