### PR TITLE
use cellIndex to get sortIndex from th

### DIFF
--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -235,7 +235,7 @@ Template.reactiveTable.helpers({
 
 Template.reactiveTable.events({
     "click .reactive-table .sortable": function (event) {
-        var sortIndex = parseInt($(event.target).attr("index"), 10);
+        var sortIndex = event.target.cellIndex;
         var group = $(event.target).parents('.reactive-table').attr('reactive-table-group');
         var currentSortIndex = Session.get(getSessionSortKey(group));
         if (currentSortIndex === sortIndex) {


### PR DESCRIPTION
Using an array of objects as a data source I found

``` javascript
var sortIndex = parseInt($(event.target).attr("index"), 10)
```

is `-1`, so `var sortKeyField = this.fields[-1]` is `undefined` and causes
`TypeError: Cannot read property 'fn' of undefined` on line 178 of reactive_table.js when `sortKeyField.fn` is referenced.

Any reason not to use `cellIndex`? Works well for me :)
