### PR TITLE
Added support for template to render cells

### DIFF
--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -53,7 +53,7 @@
         {{#each sortedRows}}
           <tr>
             {{#each ../fields}}
-              <td class="{{key}}">{{getField ..}}</td>
+              <td class="{{key}}">{{#if tmpl}}{{#with ..}}{{> ../tmpl}}{{/with}}{{else}}{{getField ..}}{{/if}}</td>
             {{/each}}
           </tr>
         {{/each}}


### PR DESCRIPTION
Hello,

this patch is very small, but very useful in imho :)

To explain it, a little example. The data source contains objects like :

```
{
  _id: "xxxxxx",
  username: "name",
  roles: [ "admin", "writer", "reader" ] 
}
```

The goal is to display user roles as a list of (bootstrap) labels, and be able to remove each role individually.

the table settings (note the "tmpl" key in "tags" field):

```
{
  fields: [
    {
      key: 'name',
      label: 'Username'
    },
    {
      key: 'roles',
      label: 'Roles',
      tmpl: Template.myRolesTmpl
    }
}
```

then the template definition (the template context is the row object, so you can have access to any fields) :

```
<template name="myRolesTmpl">
  {{#each roles}}
    <span class="label label-{{roleStyle}}">{{this}}<span class="remove-role">&times;</span></span>
  {{/each}}
</template>
```

And the JavaScript coming with the template, for helpers and events

```
Template.myRolesTmpl.events({
  'click .remove-role': function(e) {
    ... code to remove a role (this) to a user ...
  }
});

Template.myRolesTmpl.roleStyle = function() {
   ... code to compute a style name according to role name (this) ...
}
```

I attach a screenshot of a similar code.

![reactive-table-tmpl](https://cloud.githubusercontent.com/assets/229339/2642333/677c1b82-bf07-11e3-9a51-b6fae7f70a85.png)

In previous versions, i was doing this using the fn fonction and the old fashion call to Template.myTemplate(), it was returning a string represention of the template. But it's not possible with 0.8.0, because a template is not a string any more, and it must be render() and insert() into dom using UI api (if you only get the string representation with toHTML(), you don't get events and reactivity).

I hope you'll like it, the description of the pull request is very long compare to the patch itself :D

Anthony.
