### PR TITLE
Support for collection-helpers

### DIFF
--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -27,7 +27,9 @@ var get = function(obj, field) {
   var value = obj;
 
   _.each(keys, function (key) {
-      if (_.isObject(value) && !_.isUndefined(value[key])) {
+      if (_.isObject(value) && _.isFunction(value[key])) {
+          value = value[key]();
+      } else if (_.isObject(value) && !_.isUndefined(value[key])) {
           value = value[key];
       } else {
           value = null;


### PR DESCRIPTION
collections.coffee

``` coffeescript
Profiles.helpers
    user: ->
        Meteor.users.findOne @userId
```

list.coffee

``` coffee
Template.listProfiles.helpers
    settings:
        fields: [
            {key: 'user.emails.0.address', label: 'Email'}
        ]
```

Patch to make dot notations works with collection-helpers members
