### PR TITLE
Added inline field editing for strings and document removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Define the settings in a helper for the template that calls reactiveTable:
 * `showNavigation`: 'always', 'never' or 'auto'.  The latter shows the navigation footer only if the collection has more rows than `rowsPerPage`.
 * `fields`: Object. Controls the columns; see below.
 * `useFontAwesome`: Boolean. Whether to use [Font Awesome](http://fortawesome.github.io/Font-Awesome/) for icons. Requires the `font-awesome` package to be installed. Default `false`.
+* `updateCollection`: Meteor Collection. Enables UI for inline editing of string values and the removal of documents. Values in the table to can be clicked to update. This feature is currently incompatible fields that use `tmpl`, and only works with `string` or `null` value types. Note that you must pass in a collection (such as `Meteor.users` or a refernece to `new Meteor.Collection('...')`), not a cursor.
 
 
 ### Styling

--- a/lib/reactive_table.css
+++ b/lib/reactive_table.css
@@ -35,3 +35,17 @@
 	position: relative;
 	top: 2px;
 }
+
+.reactive-table .editable-value{
+    cursor:pointer;
+    display:block;
+    min-height:1em;
+}
+
+.reactive-table .btn-remove-row{
+    visibility:hidden;
+}
+
+.reactive-table tr:hover .btn-remove-row{
+    visibility:inherit;
+}

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -47,14 +47,34 @@
               {{/if}}
             {{/if}}
           {{/each}}
+          {{#if updateCollection}}
+            <th class='remove-row-col'></th>
+          {{/if}}
         </tr>
       </thead>
       <tbody>
         {{#each sortedRows}}
           <tr>
             {{#each ../fields}}
-              <td class="{{key}}">{{#if tmpl}}{{#with ..}}{{> ../tmpl}}{{/with}}{{else}}{{getField ..}}{{/if}}</td>
+              <td class="{{key}}">
+                {{#if tmpl}}
+                  {{#with ..}}{{> ../tmpl}}{{/with}}
+                {{else}}
+                  {{#if ../../updateCollection}}
+                    {{#with getCellContext .. ../..}}
+                      <span class='{{#unless editable}}non-{{/unless}}editable-value'>{{display}}</span>
+                    {{/with}}
+                  {{else}}
+                    {{getField ..}}
+                  {{/if}}
+                {{/if}}
+              </td>
             {{/each}}
+            {{#if ../updateCollection}}
+              <td class='remove-row-col'>
+                <span class="btn btn-danger btn-xs btn-remove-row">&times;</span>
+              </td>
+            {{/if}}
           </tr>
         {{/each}}
       </tbody>

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -111,6 +111,7 @@ var generateSettings =  function () {
     return {
         group: group,
         collection: collection,
+        updateCollection: settings.updateCollection,
         settings: settings,
         fields: fields,
         useFontAwesome: settings.useFontAwesome,
@@ -274,6 +275,19 @@ Template.reactiveTable.helpers({
         if (Session.get(getSessionShowNavigationKey(this.group)) === 'always') return true;
         if (Session.get(getSessionShowNavigationKey(this.group)) === 'never') return false;
         return Template.reactiveTable.getPageCount.call(this) > 1;
+    },
+    'editable' : function () {
+        // TODO : Add more editable types
+        return this.actual === null || typeof this.actual === 'string';
+    },
+    'getCellContext' : function(doc, obj) {
+        return {
+            display: Template.reactiveTable.getField.call(this, doc),
+            actual: get(doc, this.key),
+            _id: doc._id,
+            key: this.key,
+            updateCollection: obj.settings.updateCollection
+        };
     }
 });
 
@@ -330,5 +344,32 @@ Template.reactiveTable.events({
         var currentPageKey = getSessionCurrentPageKey(group);
         var currentPage = Session.get(currentPageKey);
         Session.set(currentPageKey, currentPage + 1);
+    },
+
+    'click .btn-remove-row': function (event, tmpl) {
+        if (confirm(i18n('reactiveTable.confirmRemoval'))) {
+            tmpl.data.settings.updateCollection.remove({_id:this._id});
+        }
+    },
+
+    'click .editable-value': function (event) {
+        var self = this;
+        var $displayValue = $(event.currentTarget).hide();
+
+        var $input = $("<input type='text' class='inline-edit form-control'/>")
+        .on('change', function () {
+            var update = {'$set':{}};
+            update['$set'][self.key] = $(this).val();
+            self.updateCollection.update( {_id:self._id}, update );
+        })
+        .on('blur', function () {
+            $(this).remove();
+            $displayValue.show();
+        })
+        .val(this.actual);
+
+        $('.reactive-table input.inline-edit').blur();
+        $displayValue.after($input);
+        $input.focus();
     }
 });

--- a/lib/reactive_table_i18n.js
+++ b/lib/reactive_table_i18n.js
@@ -4,7 +4,8 @@ i18n.map('en', {
         show: 'Show',
         rowsPerPage: 'rows per page',
         page: 'Page',
-        of: 'of'
+        of: 'of',
+        confirmRemoval: 'Please confirm that you wish to permanently delete this item'
     }
 });
 


### PR DESCRIPTION
Another attempt at the update/delete PR I made a while ago, this time with a different approach. It uses one `updateCollection` field in the main settings object which is used to update the given collection.
- Supports virtual fields
- CSS hides the delete button if you're not hovering on the row
- Non-intrusive as possible in terms of rendering procedure when updateCollection isn't defined (it falls back to regular `getField`)
- Still only works with strings, `null` values update-able as strings
- Delete confirmation using i18n (no translations though)

I might add an 'add document' button in the future, but it gets a little presumptuous. Similar problem with datatypes, but planned to be added in the future also (such as number, boolean and date).

Again, any suggestions for improvements appreciated.
