### PR TITLE
allow column label to be an empty string

### DIFF
--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -204,7 +204,7 @@ Template.reactiveTable.helpers({
     },
 
     'getLabel': function () {
-        return this.label || this;
+        return _.isString(this.label) ? this.label : this;
     },
 
     'isSortKey': function (field, group, fields) {


### PR DESCRIPTION
Allows an empty column label when using 

```
{key : 'foo', label : '' }
```

otherwise, we get [object Object] as the column label
