### PR TITLE
filter-input: use input-event in addition to keyup

### DIFF
--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -297,7 +297,7 @@ Template.reactiveTable.events({
         }
     },
 
-    'keyup .reactive-table-filter .reactive-table-input': _.debounce(function (event) {
+    'keyup .reactive-table-filter .reactive-table-input, input .reactive-table-filter .reactive-table-input': _.debounce(function (event) {
         var filterText = $(event.target).val();
         var group = $(event.target).parents('.reactive-table-filter').attr('reactive-table-group');
         Session.set(getSessionFilterKey(group), filterText);


### PR DESCRIPTION
the input event is fired whenever the text changes, even when the user clickpastes something. this should also fix an android-related issue (backspaces aren't recognized)

i haven't tested this fix though, so be careful :)
