### PR TITLE
Added showNavigationRowsPerPage setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Define the settings in a helper for the template that calls reactiveTable:
 * `showFilter`: Boolean. Whether to display the filter box above the table. Default `true`.
 * `rowsPerPage`: Number.  The desired number of rows per page. Defaults to 10.
 * `showNavigation`: 'always', 'never' or 'auto'.  The latter shows the navigation footer only if the collection has more rows than `rowsPerPage`.
+* `showNavigationRowsPerPage`: Boolean. If the navigation footer is visible, display rows per page control. Default 'true'.
 * `fields`: Object. Controls the columns; see below.
 * `showColumnToggles`: Boolean. Adds a button to the top right that allows the user to toggle which columns are displayed. Add `hidden` to fields to hide them unless toggled on, see below. Default `false`.
 * `useFontAwesome`: Boolean. Whether to use [Font Awesome](http://fortawesome.github.io/Font-Awesome/) for icons. Requires the `font-awesome` package to be installed. Default `false`.

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -88,9 +88,11 @@
     </table>
     {{#if showNavigation}}
       <div class="reactive-table-navigation" reactive-table-group="{{group}}">
-        <div class="form-inline form-group rows-per-page">
-          <label>{{i18n 'reactiveTable.show'}}&nbsp;<input class="form-control" type="text" value="{{getRowsPerPage}}">&nbsp;{{i18n 'reactiveTable.rowsPerPage'}}</label>
-        </div>
+        {{#if showNavigationRowsPerPage}}
+          <div class="form-inline form-group rows-per-page">
+            <label>{{i18n 'reactiveTable.show'}}&nbsp;<input class="form-control" type="text" value="{{getRowsPerPage}}">&nbsp;{{i18n 'reactiveTable.rowsPerPage'}}</label>
+          </div>
+        {{/if}}
         <div class="form-inline form-group page-number">
           {{#if isntFirstPage}}
             <label class="previous-page">&lt;</label>&nbsp;&nbsp;

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -18,6 +18,10 @@ var getSessionFilterKey = function (group) {
     return group + '-reactive-table-filter';
 };
 
+var getSessionShowNavigationRowsPerPageKey = function (group) {
+    return group + '-reactive-table-show-navigationrowsperpage';
+};
+
 var getSessionShowNavigationKey = function (group) {
     return group + '-reactive-table-show-navigation';
 };
@@ -115,6 +119,7 @@ var generateSettings =  function () {
     Session.setDefault(getSessionSortDirectionKey(group), settings.sortDirectionKey || 1);
     Session.setDefault(getSessionRowsPerPageKey(group), settings.rowsPerPage || 10);
     Session.setDefault(getSessionCurrentPageKey(group), 0);
+    Session.setDefault(getSessionShowNavigationRowsPerPageKey(group), (settings.showNavigationRowsPerPage === undefined) || settings.showNavigationRowsPerPage );
     Session.setDefault(getSessionShowNavigationKey(group), settings.showNavigation || 'always');
     Session.setDefault(getSessionFilterKey(group), null);
     if (visibleFields.length > 0) {
@@ -299,6 +304,10 @@ Template.reactiveTable.helpers({
         if (Session.get(getSessionShowNavigationKey(this.group)) === 'always') return true;
         if (Session.get(getSessionShowNavigationKey(this.group)) === 'never') return false;
         return Template.reactiveTable.getPageCount.call(this) > 1;
+    },
+
+    'showNavigationRowsPerPage' : function () {
+        return Session.get(getSessionShowNavigationRowsPerPageKey(this.group));
     },
 
     'hasClass' : function (data) {


### PR DESCRIPTION
For styling reasons, but also for functional reasons (somehow tied also to #92 and #79), I need a setting not to display rows per page control when navigation footer is shown, so I added it.
