### PR TITLE
Added example for single-element-events

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,21 @@ Template.posts.events({
 });
 ```
 
+If you want single elements inside a row to become clickable, you still have to target `tr`. Otherwise `this` won't refer to the corresponding object of your targeted row. With this in mind, you have to specify a `target` inside your `'click .reactive-table tr'` eventlistener:
+
+```JavaScript
+Template.posts.events({
+  'click .reactive-table tr': function (event) {
+    event.preventDefault();
+    var post = this;
+    // checks if the actual clicked element has the class `delete`
+    if (e.target.className == "delete") {
+      Posts.remove(post._id)
+    }
+  }
+});
+```
+
 ## Internationalization
 
 Internationalization support is provided using [anti:i18n](https://github.com/anticoders/meteor-i18n).


### PR DESCRIPTION
When I started using reactive-table, I needed a virtual row to become clickable. It took me a while to find a way to accomplish this task meteor-ish. I ended up finding a quick solution in Issue #37 .

It is a common task to make specific elements inside a table clickable. That's why I think this is something every starter should know about.

Thanks for reactive-table!
