### PR TITLE
Use official Bootstrap package, without icons

### DIFF
--- a/examples/leaderboard/.meteor/packages
+++ b/examples/leaderboard/.meteor/packages
@@ -8,6 +8,5 @@ autopublish
 insecure
 aslagle:reactive-table
 anti:i18n
-mizzao:bootstrap-3
+twbs:bootstrap-noglyph
 fortawesome:fontawesome
-

--- a/examples/table-features/.meteor/packages
+++ b/examples/table-features/.meteor/packages
@@ -5,5 +5,5 @@
 
 standard-app-packages
 autopublish
-mizzao:bootstrap-3
+twbs:bootstrap-noglyph
 aslagle:reactive-table


### PR DESCRIPTION
Since we don't use the glyphicons (because we use Font Awesome, or just don't use any icons, period), use the [-noglyphicons Bootstrap package](https://atmospherejs.com/twbs/bootstrap-noglyph).
