### PR TITLE
Table column header templates (#154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,20 @@ To set labels for the column headers, use an array of field elements, each with 
         { key: 'year', label: 'Year' }
     ] }
 
-The label can be a string or a function:
+The label can be a string or a function or a Blaze Template:
 
-    { key: 'name', label: function () { return new Spacebars.SafeString('<i>Name</i>'); } }
+    { fields: [
+        { key: 'name', label: function () { return new Spacebars.SafeString('<i>Name</i>'); } }
+        { key: 'ageRange', label: Template.ageRangeColumnLabel, labelData: {ageFrom: 18, ageTo: 50}}
+    ] }
+
+where the template is defined as:
+
+    <template name="ageRangeColumnLabel">
+      <span>Age {{ageFrom}} to {{ageTo}}</span>
+    </template>
+    
+The `labelData` element is used to set the data context of the label template.
 
 All columns are sortable by default, but sorting can be disabled by setting `sortable` to false:
 

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -35,7 +35,7 @@
                     {{else}}
                       <input type="checkbox" index="{{getFieldIndex}}">
                     {{/if}}
-                    {{getLabel}}
+                    {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}
                   </label>
                 </a></li>
               {{/each}}
@@ -51,7 +51,7 @@
             {{#if isVisible}}
               {{#if isSortKey}}
                 <th class="{{getKey}} sortable {{getHeaderClass}}" index="{{getFieldIndex}}">
-                  {{getLabel}}&nbsp;&nbsp;
+                  {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
                   {{#if isAscending}}
                     {{#if ../useFontAwesome}}
                       <i class="fa fa-sort-asc"></i>
@@ -68,9 +68,9 @@
                 </th>
               {{else}}
                 {{#if isSortable}}
-                  <th class="{{getKey}} {{getHeaderClass}} sortable" index="{{getFieldIndex}}">{{getLabel}}</th>
+                  <th class="{{getKey}} {{getHeaderClass}} sortable" index="{{getFieldIndex}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                 {{else}}
-                  <th class="{{getKey}} {{getHeaderClass}}" index="{{getFieldIndex}}">{{getLabel}}</th>
+                  <th class="{{getKey}} {{getHeaderClass}}" index="{{getFieldIndex}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                 {{/if}}
               {{/if}}
             {{/if}}

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -300,6 +300,10 @@ Template.reactiveTable.helpers({
         return css;
     },
 
+    'labelIsTemplate': function () {
+        return this.label && _.isObject(this.label) && this.label instanceof Blaze.Template;
+    },
+
     'getLabel': function () {
         return _.isString(this.label) ? this.label : this.label();
     },

--- a/test/test_fields.js
+++ b/test/test_fields.js
@@ -70,6 +70,24 @@ Tinytest.add('Fields - label function', function (test) {
   );
 });
 
+Tinytest.add('Fields - label tmpl', function (test) {
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        fields: [
+          {key: 'name', label: Template.testFieldsTmpl, labelData: {name: 'foo', score: 10}}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table th'), 1, "one column should be rendered");
+      test.length($('.reactive-table th:first-child span.test').text().trim().match(/^foo10/), 1, "first column label");
+    }
+  );
+});
+
+
 Tinytest.add('Fields - header class string', function (test) {
   testTable(
     {
@@ -107,6 +125,7 @@ Tinytest.add('Fields - header class function', function (test) {
     }
   );
 });
+
 
 Tinytest.add('Fields - tmpl', function (test) {
   testTable(


### PR DESCRIPTION
Specify table column header labels as Blaze templates instead of strings or
functions.  Specify the data context for the label template using new 'labelData` field element.

Also updated README and added one additional test.