### PR TITLE
Ensure new fields can be reactively added to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ To set labels for the column headers, use an array of field elements, each with 
         { key: 'year', label: 'Year' }
     ] }
 
+Each `key` value must be unique within the `fields` array to ensure column visibility works correctly (otherwise, visibility of all same-key fields will be governed by visibility of the first same-named key in the fields array)
+
 The label can be a string or a function or a Blaze Template:
 
     { fields: [

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you're updating to Meteor 0.8.0, note that reactiveTable is now a template wi
       - [HTML](#html)
     - [Nested objects and arrays](#nested-objects-and-arrays)
     - [Hidden columns](#hidden-columns)
+    - [Dynamic columns](#dynamic-columns)
 - [Using events](#using-events)
 - [Server-side pagination and filtering](#server-side-pagination-and-filtering-beta)
   - [Server-side Settings](#server-side-settings)
@@ -150,8 +151,6 @@ To set labels for the column headers, use an array of field elements, each with 
         { key: 'year', label: 'Year' }
     ] }
 
-Each `key` value must be unique within the `fields` array to ensure column visibility works correctly (otherwise, visibility of all same-key fields will be governed by visibility of the first same-named key in the fields array)
-
 The label can be a string or a function or a Blaze Template:
 
     { fields: [
@@ -250,6 +249,46 @@ To hide a column, add `hidden` to the field. It can be a boolean or a function.
     { key: 'location', label: 'Location', hidden: function () { return true; } }
 
 If the `showColumnToggles` setting is `true`, hidden columns will be available in a dropdown and can be enabled by the user.
+
+#### Dynamic columns
+
+If you need to be able to add new columns to an existing table (e.g. in a reactive computation), you must explicitly set a unique-valued `fieldId` attribute on each and every field definition:
+
+    { fields: [
+        {
+            fieldId: 'month',
+            key: 'postingDate',
+            label: 'Posting Month',
+            fn: function (value) { return value.month; }
+        },
+        {
+            fieldId: 'year',
+            key: 'postingDate',
+            label: 'Posting Year',
+            fn: function (value) { return value.year; }
+        }
+    ] }
+
+Having unique `fieldId` values ensures that default column visibility, visibility toggling and currently sorted column work correctly when adding new columns:
+
+```javascript
+  tmpl.autorun(function() {
+    if (Session.equals('showPostingDay', true)) {
+      tmpl.fields.set(tmpl.fields.get().unshift({
+        fieldId: 'day',
+        key: 'postingDate',
+        label: 'Posting Day',
+        fn: function (value) { return value.day; }
+      }));
+    }
+  });
+```
+
+where `tmpl.fields` could be a template instance reactive variable used in a helper to provide a reactive table's settings.
+
+Reactive Table will print an error to the console if at least one field has a 'fieldId' attribute and:
+1. One or more other fields do NOT have a `fieldId` attribute, or
+2. There are duplicate (or null) `fieldId` values.
 
 ## Using events
 

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -31,9 +31,9 @@
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-target="#">
                   <label>
                     {{#if isVisible}}
-                      <input type="checkbox" checked key="{{key}}">
+                      <input type="checkbox" checked data-fieldid="{{fieldId}}">
                     {{else}}
-                      <input type="checkbox" key="{{key}}">
+                      <input type="checkbox" data-fieldid="{{fieldId}}">
                     {{/if}}
                     {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}
                   </label>

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -50,7 +50,7 @@
           {{#each fields}}
             {{#if isVisible}}
               {{#if isSortKey}}
-                <th class="{{getKey}} sortable {{getHeaderClass}}" index="{{getFieldIndex}}">
+                <th class="{{getKey}} sortable {{getHeaderClass}}" fieldid="{{getFieldFieldId}}">
                   {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
                   {{#if isAscending}}
                     {{#if ../useFontAwesome}}
@@ -68,9 +68,9 @@
                 </th>
               {{else}}
                 {{#if isSortable}}
-                  <th class="{{getKey}} {{getHeaderClass}} sortable" index="{{getFieldIndex}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                  <th class="{{getKey}} {{getHeaderClass}} sortable" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                 {{else}}
-                  <th class="{{getKey}} {{getHeaderClass}}" index="{{getFieldIndex}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                  <th class="{{getKey}} {{getHeaderClass}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                 {{/if}}
               {{/if}}
             {{/if}}

--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -31,9 +31,9 @@
                 <li role="presentation"><a role="menuitem" tabindex="-1" data-target="#">
                   <label>
                     {{#if isVisible}}
-                      <input type="checkbox" checked index="{{getFieldIndex}}">
+                      <input type="checkbox" checked key="{{key}}">
                     {{else}}
-                      <input type="checkbox" index="{{getFieldIndex}}">
+                      <input type="checkbox" key="{{key}}">
                     {{/if}}
                     {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}
                   </label>

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -150,7 +150,7 @@ var setup = function () {
             context.publicationId = new ReactiveVar();
             context.nextPublicationId = new ReactiveVar();
         } else {
-            console.log("reactiveTable error: argument is not an instance of Mongo.Collection, a cursor, or an array");
+            console.error("reactiveTable error: argument is not an instance of Mongo.Collection, a cursor, or an array");
             collection = new Mongo.Collection(null);
         }
     }
@@ -162,6 +162,28 @@ var setup = function () {
          _.keys(fields)[0] === 'hash')) {
         fields = _.without(_.keys(collection.findOne() || {}), '_id');
     }
+
+    var fieldIdsArePresentAndUnique = function (fields) {
+        var uniqueFieldIds = _.chain(fields)
+            .filter(function (field) {
+                return !_.isUndefined(field.fieldId)
+            })
+            .map(function (field) {
+                return field.fieldId;
+            })
+            .uniq()
+            .value();
+        return uniqueFieldIds.length === fields.length;
+    };
+
+    // If at least one field specifies a fieldId, all fields must specify a 
+    // fieldId with a unique value
+    if (_.find(fields, function (field) {
+        return !_.isUndefined(field.fieldId)
+        }) && !fieldIdsArePresentAndUnique(fields)) {
+        console.error("reactiveTable error: all fields must have a unique-valued fieldId if at least one has a fieldId attribute");
+        fields = [];
+    } 
 
     var sortKey = 0;
     var sortDirection = 1;
@@ -181,17 +203,24 @@ var setup = function () {
                 sortDirection = -1;
             }
         }
-        return normalizeField(field);
+        var normalizedField = normalizeField(field);
+        if (_.isUndefined(normalizedField.fieldId)) {
+            // Default fieldId to index in fields array if not present
+            console.log('Setting field:' + normalizedField.key + ' to fieldId:' + i);
+            normalizedField.fieldId = i.toString();
+        }
+        return normalizedField;
     };
 
     fields = _.map(fields, parseField);
+
     context.fields = fields;
     context.sortKey = !_.isUndefined(oldContext.sortKey) ? oldContext.sortKey : new ReactiveVar(sortKey);
     context.sortDirection = !_.isUndefined(oldContext.sortDirection) ? oldContext.sortDirection : new ReactiveVar(sortDirection);
 
     var visibleFields = [];
     _.each(fields, function (field, i) {
-        visibleFields.push({key:field.key, isVisible:getDefaultFieldVisibility(field)});
+        visibleFields.push({fieldId:field.fieldId, isVisible:getDefaultFieldVisibility(field)});
     });
     context.visibleFields = (!_.isUndefined(oldContext.visibleFields) && !_.isEmpty(oldContext.visibleFields)) ? oldContext.visibleFields : new ReactiveVar(visibleFields);
 
@@ -329,13 +358,13 @@ Template.reactiveTable.helpers({
         var visibleFields = topLevelData.visibleFields.get();
         var fields = topLevelData.fields;
 
-        var visibleField = _.findWhere(visibleFields, {key: self.key});
+        var visibleField = _.findWhere(visibleFields, {fieldId: self.fieldId});
         if (visibleField) {
             return visibleField.isVisible;
         } else {
             // Add field to visibleFields list
             var _isVisible = getDefaultFieldVisibility(self);
-            visibleFields.push({key:self.key, isVisible:_isVisible});
+            visibleFields.push({fieldId:self.fieldId, isVisible:_isVisible});
             topLevelData.visibleFields.set(visibleFields);
             return _isVisible;
         }
@@ -437,21 +466,14 @@ Template.reactiveTable.events({
     'change .reactive-table-columns-dropdown input': function (event) {
         var template = Template.instance();
         var target = $(event.target);
-        var key = target.attr('key');
+        var fieldId = target.attr('data-fieldid');
         var visibleFields = template.context.visibleFields.get();
-        var visibleField = _.findWhere(visibleFields, {key: key})
+        var visibleField = _.findWhere(visibleFields, {fieldId: fieldId});
         if (visibleField) {
             // Toggle visibility
             visibleField.isVisible = !visibleField.isVisible;
             template.context.visibleFields.set(visibleFields);
         }
-
-
-        // if (_.include(currentVisibleFields, key)) {
-        //     template.context.visibleFields.set(_.without(currentVisibleFields, key));
-        // } else {
-        //     template.context.visibleFields.set(currentVisibleFields.concat(key));
-        // }
     },
 
     'keyup .reactive-table-filter .reactive-table-input, input .reactive-table-filter .reactive-table-input': function (event) {

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -191,9 +191,7 @@ var setup = function () {
 
     var visibleFields = [];
     _.each(fields, function (field, i) {
-        if (!field.hidden || (_.isFunction(field.hidden) && !field.hidden())) {
-          visibleFields.push(i);
-        }
+        visibleFields.push({key:field.key, isVisible:getDefaultFieldVisibility(field)});
     });
     context.visibleFields = (!_.isUndefined(oldContext.visibleFields) && !_.isEmpty(oldContext.visibleFields)) ? oldContext.visibleFields : new ReactiveVar(visibleFields);
 
@@ -243,6 +241,9 @@ var setup = function () {
     this.context = context;
 };
 
+var getDefaultFieldVisibility = function (field) {
+    return !field.hidden || (_.isFunction(field.hidden) && !field.hidden());
+}
 
 var getPageCount = function () {
     var count;
@@ -318,15 +319,26 @@ Template.reactiveTable.helpers({
     },
 
     'isVisible': function () {
+        var self = this; // is a field object
         var topLevelData;
         if (Template.parentData(2) && Template.parentData(2).reactiveTableSetup) {
           topLevelData = Template.parentData(2);
         } else {
           topLevelData = Template.parentData(1);
         }
-        var visibleFields = topLevelData.visibleFields;
+        var visibleFields = topLevelData.visibleFields.get();
         var fields = topLevelData.fields;
-        return _.include(visibleFields.get(), _.indexOf(fields, this));
+
+        var visibleField = _.findWhere(visibleFields, {key: self.key});
+        if (visibleField) {
+            return visibleField.isVisible;
+        } else {
+            // Add field to visibleFields list
+            var _isVisible = getDefaultFieldVisibility(self);
+            visibleFields.push({key:self.key, isVisible:_isVisible});
+            topLevelData.visibleFields.set(visibleFields);
+            return _isVisible;
+        }
     },
 
     'isAscending' : function () {
@@ -425,13 +437,21 @@ Template.reactiveTable.events({
     'change .reactive-table-columns-dropdown input': function (event) {
         var template = Template.instance();
         var target = $(event.target);
-        var index = parseInt(target.attr('index'), 10);
-        var currentVisibleFields = template.context.visibleFields.get()
-        if (_.include(currentVisibleFields, index)) {
-            template.context.visibleFields.set(_.without(currentVisibleFields, index));
-        } else {
-            template.context.visibleFields.set(currentVisibleFields.concat(index));
+        var key = target.attr('key');
+        var visibleFields = template.context.visibleFields.get();
+        var visibleField = _.findWhere(visibleFields, {key: key})
+        if (visibleField) {
+            // Toggle visibility
+            visibleField.isVisible = !visibleField.isVisible;
+            template.context.visibleFields.set(visibleFields);
         }
+
+
+        // if (_.include(currentVisibleFields, key)) {
+        //     template.context.visibleFields.set(_.without(currentVisibleFields, key));
+        // } else {
+        //     template.context.visibleFields.set(currentVisibleFields.concat(key));
+        // }
     },
 
     'keyup .reactive-table-filter .reactive-table-input, input .reactive-table-filter .reactive-table-input': function (event) {

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -44,8 +44,11 @@ var updateHandle = _.debounce(function () {
             limit: rowsPerPage
         };
         var sortQuery = {};
-        var sortField = context.fields[context.sortKey.get()].key;
-        sortQuery[sortField] = context.sortDirection.get();
+
+        var currentSortField = _.findWhere(context.fields, {fieldId: context.sortKey.get()});
+        if (currentSortField) {
+            sortQuery[currentSortField.key] = context.sortDirection.get();
+        }
         options.sort = sortQuery;
         var filter = context.filter.get();
 
@@ -185,7 +188,7 @@ var setup = function () {
         fields = [];
     } 
 
-    var sortKey = 0;
+    var sortKey = null;
     var sortDirection = 1;
 
     var normalizeField = function (field) {
@@ -197,23 +200,25 @@ var setup = function () {
     };
 
     var parseField = function (field, i) {
-        if (field.sort) {
-            sortKey = i;
-            if (field.sort === 'desc' || field.sort === 'descending'  || field.sort === -1) {
+        var normalizedField = normalizeField(field);
+        if (!_.has(normalizedField, 'fieldId')) {
+            // Default fieldId to index in fields array if not present
+            normalizedField.fieldId = i.toString();
+        }
+        if (normalizedField.sort) {
+            sortKey = normalizedField.fieldId;
+            if (normalizedField.sort === 'desc' || normalizedField.sort === 'descending'  || normalizedField.sort === -1) {
                 sortDirection = -1;
             }
-        }
-        var normalizedField = normalizeField(field);
-        if (_.isUndefined(normalizedField.fieldId)) {
-            // Default fieldId to index in fields array if not present
-            console.log('Setting field:' + normalizedField.key + ' to fieldId:' + i);
-            normalizedField.fieldId = i.toString();
         }
         return normalizedField;
     };
 
     fields = _.map(fields, parseField);
-
+    if (!sortKey) {
+        // Default to sort of first column
+        sortKey = (fields[0]) ? fields[0].fieldId : null;
+    }
     context.fields = fields;
     context.sortKey = !_.isUndefined(oldContext.sortKey) ? oldContext.sortKey : new ReactiveVar(sortKey);
     context.sortDirection = !_.isUndefined(oldContext.sortDirection) ? oldContext.sortDirection : new ReactiveVar(sortDirection);
@@ -313,6 +318,10 @@ Template.reactiveTable.helpers({
         return _.indexOf(Template.parentData(1).fields, this);
     },
 
+    'getFieldFieldId': function () {
+        return this.fieldId;
+    },
+
     'getKey': function () {
         return this.key || this;
     },
@@ -340,7 +349,7 @@ Template.reactiveTable.helpers({
 
     'isSortKey': function () {
         var parentData = Template.parentData(1);
-        return parentData.sortKey.get() == _.indexOf(parentData.fields, this);
+        return parentData.sortKey.get() === this.fieldId;
     },
 
     'isSortable': function () {
@@ -386,15 +395,21 @@ Template.reactiveTable.helpers({
             });
         } else  {
             var sortDirection = this.sortDirection.get();
-            var sortKeyIndex = this.sortKey.get();
-            var sortKeyField = this.fields[sortKeyIndex] || {};
+            var sortKeyFieldId = this.sortKey.get();
+            var sortKeyField = _.findWhere(this.fields, {fieldId: sortKeyFieldId});
 
             var limit = this.rowsPerPage.get();
             var currentPage = this.currentPage.get();
             var skip = currentPage * limit;
             var filterQuery = getFilterQuery(this.filter.get(), this.fields, {enableRegex: this.enableRegex});
 
-            if (sortKeyField.fn && !sortKeyField.sortByValue) {
+            if (!sortKeyField) {
+                // No sort field set, return unsorted collection
+                return this.collection.find(filterQuery, {
+                    skip: skip,
+                    limit: limit
+                }); 
+            } else if (sortKeyField.fn && !sortKeyField.sortByValue) {
                 var data = this.collection.find(filterQuery).fetch();
                 var sorted =_.sortBy(data, function (object) {
                     return sortKeyField.fn(object[sortKeyField.key], object);
@@ -452,13 +467,13 @@ Template.reactiveTable.events({
     'click .reactive-table .sortable': function (event) {
         var template = Template.instance();
         var target = $(event.target).is('i') ? $(event.target).parent() : $(event.target);
-        var sortIndex = parseInt(target.attr('index'), 10);
-        var currentSortIndex = template.context.sortKey.get();
-        if (currentSortIndex === sortIndex) {
+        var sortFieldId = target.attr('fieldid');
+        var currentSortFieldId = template.context.sortKey.get();
+        if (currentSortFieldId === sortFieldId) {
             var sortDirection = -1 * template.context.sortDirection.get();
             template.context.sortDirection.set(sortDirection);
         } else {
-            template.context.sortKey.set(sortIndex);
+            template.context.sortKey.set(sortFieldId);
         }
         updateHandle.call(template.context);
     },

--- a/test/test_column_toggles.js
+++ b/test/test_column_toggles.js
@@ -32,7 +32,7 @@ Tinytest.add('Column Toggles - hidden columns', function (test) {
         showColumnToggles: true,
         fields: [
           {key: 'name', label: 'Visible'},
-          {key: 'name', label: 'Hidden', hidden: true}
+          {key: 'score', label: 'Hidden', hidden: true}
         ]
       }
     },
@@ -45,6 +45,50 @@ Tinytest.add('Column Toggles - hidden columns', function (test) {
   );
 });
 
+Tinytest.add('Column Toggles - hidden columns with non-unique names', function (test) {
+  /**
+   * Tests expected erroneous column visibility behaviour if table has duplicate field keys
+   */
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        showColumnToggles: true,
+        fields: [
+          {key: 'name', label: 'Visible'},
+          {key: 'name', label: 'Hidden', hidden: true}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table-columns-dropdown'), 1, "column toggle button should be visible");
+      test.length($('.reactive-table th'), 2, "two columns should be displayed");
+      test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
+      test.length($('.reactive-table-columns-dropdown input:checked'), 2, "both boxes should be checked");
+    }
+  );
+
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        showColumnToggles: true,
+        fields: [
+          {key: 'name', label: 'Hidden', hidden: true},
+          {key: 'name', label: 'Visible'}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table-columns-dropdown'), 1, "column toggle button should be visible");
+      test.length($('.reactive-table th'), 0, "no columns should be displayed");
+      test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
+      test.length($('.reactive-table-columns-dropdown input:checked'), 0, "no boxes should be checked");
+    }
+  );
+
+});
+
 testAsyncMulti('Column Toggles - toggling', [function (test, expect) {
   var table = Blaze.renderWithData(
     Template.reactiveTable,
@@ -53,7 +97,7 @@ testAsyncMulti('Column Toggles - toggling', [function (test, expect) {
       showColumnToggles: true,
       fields: [
         {key: 'name', label: 'Visible'},
-        {key: 'name', label: 'Hidden', hidden: true}
+        {key: 'score', label: 'Hidden', hidden: true}
       ]
     },
     document.body
@@ -77,10 +121,10 @@ testAsyncMulti('Column Toggles - toggling', [function (test, expect) {
     test.length($('.reactive-table th:first-child').text().trim().match(/Visible/), 1, "visible column should still be displayed");
     test.length($('.reactive-table th:nth-child(2)').text().trim().match(/Hidden/), 1, "initially hidden column should now be displayed");
 
-    $('.reactive-table-columns-dropdown input[index=0]').click();
+    $('.reactive-table-columns-dropdown input[key="name"]').click();
     Meteor.setTimeout(expectSecondColumnOnly, 0);
   });
 
-  $('.reactive-table-columns-dropdown input[index=1]').click();
+  $('.reactive-table-columns-dropdown input[key="score"]').click();
   Meteor.setTimeout(expectBothColumns, 0);
 }]);

--- a/test/test_column_toggles.js
+++ b/test/test_column_toggles.js
@@ -45,9 +45,9 @@ Tinytest.add('Column Toggles - hidden columns', function (test) {
   );
 });
 
-Tinytest.add('Column Toggles - hidden columns with non-unique names', function (test) {
+Tinytest.add('Column Toggles - hidden columns with non-unique keys', function (test) {
   /**
-   * Tests expected erroneous column visibility behaviour if table has duplicate field keys
+   * Tests legacy behaviour of duplicate key values without specifying a fieldId
    */
   testTable(
     {
@@ -62,9 +62,9 @@ Tinytest.add('Column Toggles - hidden columns with non-unique names', function (
     },
     function () {
       test.length($('.reactive-table-columns-dropdown'), 1, "column toggle button should be visible");
-      test.length($('.reactive-table th'), 2, "two columns should be displayed");
+      test.length($('.reactive-table th'), 1, "one columns should be displayed");
       test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
-      test.length($('.reactive-table-columns-dropdown input:checked'), 2, "both boxes should be checked");
+      test.length($('.reactive-table-columns-dropdown input:checked'), 1, "one box should be checked");
     }
   );
 
@@ -81,12 +81,33 @@ Tinytest.add('Column Toggles - hidden columns with non-unique names', function (
     },
     function () {
       test.length($('.reactive-table-columns-dropdown'), 1, "column toggle button should be visible");
-      test.length($('.reactive-table th'), 0, "no columns should be displayed");
+      test.length($('.reactive-table th'), 1, "one column should be displayed");
       test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
-      test.length($('.reactive-table-columns-dropdown input:checked'), 0, "no boxes should be checked");
+      test.length($('.reactive-table-columns-dropdown input:checked'), 1, "one box should be checked");
     }
   );
 
+});
+
+Tinytest.add('Column Toggles - hidden columns with fieldIds', function (test) {
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        showColumnToggles: true,
+        fields: [
+          {fieldId: 'one', key: 'name', label: 'Visible'},
+          {fieldId: 'two', key: 'score', label: 'Hidden', hidden: true}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table-columns-dropdown'), 1, "column toggle button should be visible");
+      test.length($('.reactive-table th'), 1, "one column should be displayed");
+      test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
+      test.length($('.reactive-table-columns-dropdown input:checked'), 1, "only one box should be checked");
+    }
+  );
 });
 
 testAsyncMulti('Column Toggles - toggling', [function (test, expect) {
@@ -121,10 +142,137 @@ testAsyncMulti('Column Toggles - toggling', [function (test, expect) {
     test.length($('.reactive-table th:first-child').text().trim().match(/Visible/), 1, "visible column should still be displayed");
     test.length($('.reactive-table th:nth-child(2)').text().trim().match(/Hidden/), 1, "initially hidden column should now be displayed");
 
-    $('.reactive-table-columns-dropdown input[key="name"]').click();
+    $('.reactive-table-columns-dropdown input[data-fieldid="0"]').click();
     Meteor.setTimeout(expectSecondColumnOnly, 0);
   });
 
-  $('.reactive-table-columns-dropdown input[key="score"]').click();
+  $('.reactive-table-columns-dropdown input[data-fieldid="1"]').click();
   Meteor.setTimeout(expectBothColumns, 0);
+}]);
+
+testAsyncMulti('Column Toggles - toggling after adding new columns with fieldId', [function (test, expect) {
+  var insert2ndField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (insert2ndField.get()) {
+        return {
+          showColumnToggles: true,
+          fields: [
+            {fieldId: 'one', key: 'name', label: 'Name'},
+            {fieldId: 'two', key: 'score', label: 'Score'},
+            {fieldId: 'three', key: 'average', label: 'Average'}
+           ]
+        }
+      } else {
+        return {
+          showColumnToggles: true,
+          fields: [
+            {fieldId: 'one', key: 'name', label: 'Name'},
+            {fieldId: 'three', key: 'average', label: 'Average'}
+          ]
+        }
+      }
+    }
+  });
+
+  var table = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.length($('.reactive-table th'), 2, "two columns should be displayed");
+  test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
+  test.length($('.reactive-table-columns-dropdown input:checked'), 2, "both boxes should be checked");
+
+  var expectColumnsOneAndTwoOnly = expect(function () {
+    test.length($('.reactive-table th'), 2, "two columns should be displayed");
+    test.length($('.reactive-table-columns-dropdown input'), 3, "three checkboxes should be available");
+    test.length($('.reactive-table-columns-dropdown input:checked'), 2, "two checkboxes box should be checked");
+    test.length($('.reactive-table-columns-dropdown input:checked[data-fieldid="two"]'), 1, "newly inserted field should be checked");
+    test.length($('.reactive-table-columns-dropdown input:checked[data-fieldid="three"]'), 0, "previously hidden field should still be unchecked");
+    test.length($('.reactive-table th:first-child').text().trim().match(/Name/), 1, "Name column should still be visible");
+    test.length($('.reactive-table th:nth-child(2)').text().trim().match(/Score/), 1, "Score column should now be visible");
+
+    Blaze.remove(table);
+  });
+
+  var expectOneColumnOnly = expect(function () {
+    test.length($('.reactive-table th'), 1, "one columns should be displayed");
+    test.length($('.reactive-table-columns-dropdown input:checked'), 1, "one box should be checked");
+    test.length($('.reactive-table th:first-child').text().trim().match(/Name/), 1, "visible column should still be displayed");
+
+    insert2ndField.set(true);
+    Meteor.setTimeout(expectColumnsOneAndTwoOnly, 0);
+  });
+
+  $('.reactive-table-columns-dropdown input[data-fieldid="three"]').click();
+  Meteor.setTimeout(expectOneColumnOnly, 0);
+}]);
+
+testAsyncMulti('Column Toggles - toggling after adding new columns without fieldIds', [function (test, expect) {
+  var insert2ndField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (insert2ndField.get()) {
+        return {
+          showColumnToggles: true,
+          fields: [
+            {key: 'name', label: 'Name'},
+            {key: 'score', label: 'Score'},
+            {key: 'average', label: 'Average'}
+           ]
+        }
+      } else {
+        return {
+          showColumnToggles: true,
+          fields: [
+            {key: 'name', label: 'Name'},
+            {key: 'average', label: 'Average'}
+          ]
+        }
+      }
+    }
+  });
+
+  var table = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.length($('.reactive-table th'), 2, "two columns should be displayed");
+  test.length($('.reactive-table-columns-dropdown input'), 2, "two checkboxes should be available");
+  test.length($('.reactive-table-columns-dropdown input:checked'), 2, "both boxes should be checked");
+
+  var expectColumnsOneAndTwoOnly = expect(function () {
+    test.length($('.reactive-table th'), 2, "two columns should be displayed");
+    test.length($('.reactive-table-columns-dropdown input'), 3, "three checkboxes should be available");
+    test.length($('.reactive-table-columns-dropdown input:checked'), 2, "two checkboxes box should be checked");
+    test.length($('.reactive-table th:first-child').text().trim().match(/Name/), 1, "Name column should still be visible");
+
+    // Tests for known erroneous behaviour in this case if fieldIds are not explicitly set:
+    test.length($('.reactive-table-columns-dropdown input:checked[data-fieldid="1"]'), 0, "newly inserted field will be unchecked");
+    test.length($('.reactive-table th:nth-child(2)').text().trim().match(/Average/), 1, "Average column will still be visible");
+
+    Blaze.remove(table);
+  });
+
+  var expectOneColumnOnly = expect(function () {
+    test.length($('.reactive-table th'), 1, "one columns should be displayed");
+    test.length($('.reactive-table-columns-dropdown input:checked'), 1, "one box should be checked");
+    test.length($('.reactive-table th:first-child').text().trim().match(/Name/), 1, "visible column should still be displayed");
+
+    insert2ndField.set(true);
+    Meteor.setTimeout(expectColumnsOneAndTwoOnly, 0);
+  });
+
+  $('.reactive-table-columns-dropdown input[data-fieldid="1"]').click();
+  Meteor.setTimeout(expectOneColumnOnly, 0);
 }]);

--- a/test/test_fields.js
+++ b/test/test_fields.js
@@ -28,13 +28,65 @@ Tinytest.add('Fields - array', function (test) {
   );
 });
 
-Tinytest.add('Fields - non-unique keys', function (test) {
+Tinytest.add('Fields - array with non-unique keys', function (test) {
   testTable(
     {collection: rows, fields: ['name', 'name']},
     function () {
       test.length($('.reactive-table th'), 2, "two columns should be rendered");
       test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
       test.length($('.reactive-table th:nth-child(2)').text().trim().match(/^name/), 1, "second column should be name also");
+    }
+  );
+});
+
+Tinytest.add('Fields - fieldIds', function (test) {
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        fields: [
+          {fieldId: 'one', key: 'name', label: 'Name'},
+          {fieldId: 'two', key: 'score', label: 'Score'}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table th'), 2, "two columns should be rendered");
+      test.length($('.reactive-table th:first-child').text().trim().match(/^Name/), 1, "first column should be name");
+      test.length($('.reactive-table th:nth-child(2)').text().trim().match(/^Score/), 1, "second column should be score");
+    }
+  );
+});
+
+Tinytest.add('Fields - erroneous fieldIds', function (test) {
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        fields: [
+          {fieldId: 'one', key: 'name'},
+          {fieldId: 'one', key: 'score'}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table th'), 0, "no columns should be rendered");
+    }
+  );
+
+  // If one field specifies fieldId, all fields must specify a fieldId
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        fields: [
+          {key: 'name'},
+          {fieldId: 'two', key: 'score'}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table th'), 0, "no columns should be rendered");
     }
   );
 });

--- a/test/test_fields.js
+++ b/test/test_fields.js
@@ -28,6 +28,17 @@ Tinytest.add('Fields - array', function (test) {
   );
 });
 
+Tinytest.add('Fields - non-unique keys', function (test) {
+  testTable(
+    {collection: rows, fields: ['name', 'name']},
+    function () {
+      test.length($('.reactive-table th'), 2, "two columns should be rendered");
+      test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+      test.length($('.reactive-table th:nth-child(2)').text().trim().match(/^name/), 1, "second column should be name also");
+    }
+  );
+});
+
 Tinytest.add('Fields - label string', function (test) {
   testTable(
     {
@@ -319,7 +330,7 @@ Tinytest.add('Fields - hidden', function (test) {
       settings: {
         fields: [
           {key: 'name', label: 'Visible', hidden: false},
-          {key: 'name', label: 'Hidden', hidden: true}
+          {key: 'score', label: 'Hidden', hidden: true}
         ]
       }
     },
@@ -335,7 +346,7 @@ Tinytest.add('Fields - hidden', function (test) {
       collection: rows,
       fields: [
         {key: 'name', label: 'Visible', hidden: function () { return false; }},
-        {key: 'name', label: 'Hidden', hidden: function () { return true; }}
+        {key: 'score', label: 'Hidden', hidden: function () { return true; }}
       ]
     },
     function () {

--- a/test/test_reactivity.js
+++ b/test/test_reactivity.js
@@ -159,7 +159,7 @@ testAsyncMulti('Reactivity - user setting persists when other arguments change',
   showCollection.set(true);
 }]);
 
-testAsyncMulti('Reactivity - adding new visible field', [function (test, expect) {
+testAsyncMulti('Reactivity - adding new visible field with fieldIds', [function (test, expect) {
   var add2ndField = new ReactiveVar(false);
   Template.testReactivity.helpers({
     collection: function () {
@@ -169,14 +169,14 @@ testAsyncMulti('Reactivity - adding new visible field', [function (test, expect)
       if (add2ndField.get()) {
         return {
           fields: [
-            {key: 'name', label: 'name', hidden: false},
-            {key: 'score', label: 'score', hidden: false}
+            {fieldId: 'one', key: 'name', label: 'name', hidden: false},
+            {fieldId: 'two', key: 'score', label: 'score', hidden: false}
           ]
         }
       } else {
         return {
           fields: [
-            {key: 'name', label: 'name', hidden: false}
+            {fieldId: 'one', key: 'name', label: 'name', hidden: false}
           ]
         }
       }
@@ -201,7 +201,7 @@ testAsyncMulti('Reactivity - adding new visible field', [function (test, expect)
   }), 0);
 }]);
 
-testAsyncMulti('Reactivity - adding new hidden field', [function (test, expect) {
+testAsyncMulti('Reactivity - adding new hidden field with fieldIds', [function (test, expect) {
   var add2ndField = new ReactiveVar(false);
   Template.testReactivity.helpers({
     collection: function () {
@@ -211,14 +211,14 @@ testAsyncMulti('Reactivity - adding new hidden field', [function (test, expect) 
       if (add2ndField.get()) {
         return {
           fields: [
-            {key: 'name', label: 'name', hidden: false},
-            {key: 'score', label: 'score', hidden: true}
+            {fieldId: 'one', key: 'name', label: 'name', hidden: false},
+            {fieldId: 'two', key: 'score', label: 'score', hidden: true}
           ]
         }
       } else {
         return {
           fields: [
-            {key: 'name', label: 'name', hidden: false}
+            {fieldId: 'one', key: 'name', label: 'name', hidden: false}
           ]
         }
       }
@@ -243,6 +243,47 @@ testAsyncMulti('Reactivity - adding new hidden field', [function (test, expect) 
   }), 0);
 }]);
 
+testAsyncMulti('Reactivity - adding new visible field without fieldIds', [function (test, expect) {
+  var add2ndField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (add2ndField.get()) {
+        return {
+          fields: [
+            {key: 'score', label: 'score', hidden: false},
+            {key: 'name', label: 'name', hidden: false}
+          ]
+        }
+      } else {
+        return {
+          fields: [
+            {key: 'name', label: 'name', hidden: false}
+          ]
+        }
+      }
+    }
+  });
+
+  var view = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.length($('.reactive-table th'), 1, "one column should be rendered");
+  test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+
+  add2ndField.set(true);
+  Meteor.setTimeout(expect(function () {
+    test.length($('.reactive-table th'), 2, "two columns should be rendered");
+    test.length($('.reactive-table th:first-child').text().trim().match(/^score/), 1, "first column should be score");
+    test.length($('.reactive-table th:nth-child(2)').text().trim().match(/^name/), 1, "second column should be name");
+    Blaze.remove(view);
+  }), 0);
+}]);
 
 testAsyncMulti('Reactivity - server-side collection', [function (test, expect) {
   var table = Blaze.renderWithData(

--- a/test/test_reactivity.js
+++ b/test/test_reactivity.js
@@ -159,6 +159,91 @@ testAsyncMulti('Reactivity - user setting persists when other arguments change',
   showCollection.set(true);
 }]);
 
+testAsyncMulti('Reactivity - adding new visible field', [function (test, expect) {
+  var add2ndField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (add2ndField.get()) {
+        return {
+          fields: [
+            {key: 'name', label: 'name', hidden: false},
+            {key: 'score', label: 'score', hidden: false}
+          ]
+        }
+      } else {
+        return {
+          fields: [
+            {key: 'name', label: 'name', hidden: false}
+          ]
+        }
+      }
+    }
+  });
+
+  var view = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.length($('.reactive-table th'), 1, "one column should be rendered");
+  test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+
+  add2ndField.set(true);
+  Meteor.setTimeout(expect(function () {
+    test.length($('.reactive-table th'), 2, "two columns should be rendered");
+    test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+    test.length($('.reactive-table th:nth-child(2)').text().trim().match(/^score/), 1, "second column should be score");
+    Blaze.remove(view);
+  }), 0);
+}]);
+
+testAsyncMulti('Reactivity - adding new hidden field', [function (test, expect) {
+  var add2ndField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (add2ndField.get()) {
+        return {
+          fields: [
+            {key: 'name', label: 'name', hidden: false},
+            {key: 'score', label: 'score', hidden: true}
+          ]
+        }
+      } else {
+        return {
+          fields: [
+            {key: 'name', label: 'name', hidden: false}
+          ]
+        }
+      }
+    }
+  });
+
+  var view = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.length($('.reactive-table th'), 1, "one column should be rendered");
+  test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+
+  add2ndField.set(true);
+  Meteor.setTimeout(expect(function () {
+    test.length($('.reactive-table th'), 1, "one column should be rendered");
+    test.length($('.reactive-table th:first-child').text().trim().match(/^name/), 1, "first column should be name");
+    test.isNull($('.reactive-table th:nth-child(2)').text().trim().match(/^score/), 1, "second column should be hidden");
+    Blaze.remove(view);
+  }), 0);
+}]);
+
+
 testAsyncMulti('Reactivity - server-side collection', [function (test, expect) {
   var table = Blaze.renderWithData(
     Template.reactiveTable,
@@ -196,3 +281,4 @@ testAsyncMulti('Reactivity - server-side collection', [function (test, expect) {
 
   Meteor.setTimeout(expectInitialRow, 500);
 }]);
+

--- a/test/test_sorting.js
+++ b/test/test_sorting.js
@@ -58,6 +58,60 @@ testAsyncMulti('Sorting - column', [function (test, expect) {
   Meteor.setTimeout(expectSecondColumn, 0);
 }]);
 
+testAsyncMulti('Sorting - after adding new column with fieldIds', [function (test, expect) {
+  var insert1stField = new ReactiveVar(false);
+  Template.testReactivity.helpers({
+    collection: function () {
+      return collection;
+    },
+    settings: function () {
+      if (insert1stField.get()) {
+        return {
+          fields: [
+            {fieldId: 'name', key: 'name', label: 'Name'},
+            {fieldId: 'score', key: 'score', label: 'Score'}
+           ]
+        }
+      } else {
+        return {
+          fields: [
+            {fieldId: 'score', key: 'score', label: 'Score'},
+          ]
+        }
+      }
+    }
+  });
+
+  var table = Blaze.renderWithData(
+    Template.testReactivity,
+    {},
+    document.body
+  );
+
+  test.equal($('.reactive-table tbody tr:first-child td:first-child').text(), "0", "initial first row");
+  test.equal($('.reactive-table tbody tr:nth-child(2) td:first-child').text(), "5", "initial second row");
+  test.equal($('.reactive-table tbody tr:nth-child(5) td:first-child').text(), "10", "initial fifth row");
+
+  var expectSecondColumnStillDescending = expect(function () {
+    test.equal($('.reactive-table tbody tr:first-child td:nth-child(2)').text(), "15", "2nd column descending first row");
+    test.equal($('.reactive-table tbody tr:nth-child(2) td:nth-child(2)').text(), "10", "2nd column descending second row");
+    test.equal($('.reactive-table tbody tr:nth-child(5) td:nth-child(2)').text(), "5", "2nd column descending fifth row");
+    Blaze.remove(table);
+  });
+
+  var expectDescending = expect(function () {
+    test.equal($('.reactive-table tbody tr:first-child td:first-child').text(), "15", "descending first row");
+    test.equal($('.reactive-table tbody tr:nth-child(2) td:first-child').text(), "10", "descending second row");
+    test.equal($('.reactive-table tbody tr:nth-child(5) td:first-child').text(), "5", "descending fifth row");
+
+    insert1stField.set(true);
+    Meteor.setTimeout(expectSecondColumnStillDescending, 0);
+  });
+
+  $('.reactive-table th:first-child').click();
+  Meteor.setTimeout(expectDescending, 0);
+}]);
+
 testAsyncMulti('Sorting - server-side', [function (test, expect) {
   var table = Blaze.renderWithData(
     Template.reactiveTable,


### PR DESCRIPTION
Instead of using the index of a field in the fields array to control
its visibility, use a dictionary of key / isVisible pairs.
This enables the code to detect if a field has been added reactively
and therefore set its default visibility correctly.

Note that this change now means that field key values must be unique
for column visibility control to work correctly (this wasn’t the case
before).  If there are non-unique key names, the visibility of the
first such field in the fields array will govern the visibility of all
of those fields.

This commit also includes corrected and added package tests related to
this change, and note in the README about consequences of non-unique
field keys.

Fixes #156 