### PR TITLE
Fixed Turkish translation

### DIFF
--- a/lib/reactive_table_i18n.js
+++ b/lib/reactive_table_i18n.js
@@ -93,8 +93,8 @@ i18n.map('tr', {
     reactiveTable: {
         filter: 'Süz',
         columns: 'Sütunlar',
-        show: 'Göster',
-        rowsPerPage: 'sayfa başına',
+        show: 'Sayfa başına',
+        rowsPerPage: 'satır göster',
         page: 'Sayfa',
         of: ' / '
     }


### PR DESCRIPTION
Fixed Turkish translation according to context where the sentence wording order is backwards. So `show` and `rowsPerPage` need to switch places in order to provide the correct context.

PS: Thanks for being *very* fast in accepting the PR, but I needed to make additional improvement. Sorry for sending two consecutive PR's.