### PR TITLE
add getHeaderStyle and getCellStyle

### DIFF
--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -40,7 +40,7 @@
             {{#each fields}}
               {{#if isVisible}}
                 {{#if isPrimarySortField}}
-                  <th class="sortable {{getHeaderClass}}" fieldid="{{getFieldFieldId}}">
+                  <th class="sortable {{getHeaderClass}}" style="{{getHeaderStyle}}" fieldid="{{getFieldFieldId}}">
                     {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
                     {{#if isAscending}}
                       {{#if ../useFontAwesome}}
@@ -58,9 +58,9 @@
                   </th>
                 {{else}}
                   {{#if isSortable}}
-                    <th class="{{getHeaderClass}} sortable" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                    <th class="{{getHeaderClass}} sortable" style="{{getHeaderStyle}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                   {{else}}
-                    <th class="{{getHeaderClass}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                    <th class="{{getHeaderClass}}" style="{{getHeaderStyle}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                   {{/if}}
                 {{/if}}
               {{/if}}
@@ -72,7 +72,7 @@
             <tr class="{{../rowClass this}}">
               {{#each ../fields}}
                 {{#if isVisible}}
-                  <td class="{{getCellClass ..}}">{{#if tmpl}}{{#with ..}}{{> ../tmpl}}{{/with}}{{else}}{{getField ..}}{{/if}}</td>
+                  <td class="{{getCellClass ..}}" style="{{getCellStyle ..}}">{{#if tmpl}}{{#with ..}}{{> ../tmpl}}{{/with}}{{else}}{{getField ..}}{{/if}}</td>
                 {{/if}}
               {{/each}}
             </tr>

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -373,6 +373,19 @@ Template.reactiveTable.helpers({
         return css;
     },
 
+    'getHeaderStyle': function () {
+        if (_.isUndefined(this.headerStyle)) {
+            return;
+        }
+        var style;
+        if (_.isFunction(this.headerStyle)) {
+            style = this.headerStyle();
+        } else {
+            style = this.headerStyle;
+        }
+        return style;
+    },
+
     'getCellClass': function (object) {
         if (_.isUndefined(this.cellClass)) {
             return this.key;
@@ -385,6 +398,20 @@ Template.reactiveTable.helpers({
             css = this.cellClass;
         }
         return css;
+    },
+
+    'getCellStyle': function (object) {
+        if (_.isUndefined(this.cellStyle)) {
+            return;
+        }
+        var style;
+        if (_.isFunction(this.cellStyle)) {
+            var value = get(object, this.key);
+            style = this.cellStyle(value, object);
+        } else {
+            style = this.cellStyle;
+        }
+        return style;
     },
 
     'labelIsTemplate': function () {


### PR DESCRIPTION
Hi again.
I have implemented features, that I needed some time ago: it is all about "style" attribute for header and cell of table columns. I [asked](https://github.com/aslagle/reactive-table/issues/196) you about that, got some advice... But did not solve my task. Let me explain: I have to do positioning and other styling of content in the cells of a table and also I have to implement something kind of interactive styling for separate cells, but I can't work with file system (yet) to dynamically edit CSS-files. I tried, as you [adviced](https://github.com/aslagle/reactive-table/issues/196#issuecomment-91267692) me, to put all content in separate templates and to apply styles of them... it is good advice, but I got new issue: width and height of "DIV" elements in the cells did not inherit parameters of parent "TDs"... making them "100% width, height" did not solve it too btw. But then I found little css-trick, that could solve my problem... at least I guessed that... I made my divs to take all width and height of their parent elements - "TDs", but "vertical-align" property did not align contents at all... And my patience got broken... may be I should look for how to solve new problem, but I did not do that. And I made a decision to implement "Style feature for cells and headers" and I could do it! It was faster and easier then all my tryings before with templates and other... So I made this PR.