### PR TITLE
added serverArgs (fixes #255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The reactiveTable helper accepts additional arguments that can be used to config
 * `class`: String. Classes to add to the table element in addition to 'reactive-table'. Default: 'table table-striped table-hover col-sm-12'.
 * `id`: String. Unique id to add to the table element. Default: generated with [_.uniqueId](http://underscorejs.org/#uniqueId).
 * `rowClass`: String or function returning a class name. The row element will be passed as first parameter.
+* `serverArgs` Will be passed to `collection` and `selector` functions on serverside.
 
 #### rowClass examples
 
@@ -385,8 +386,8 @@ Use ReactiveTable.publish on the server to make a collection available to reacti
 
 Arguments:
 - name: The name of the publication
-- collection: A function that returns the collection to publish (or just a collection, if it's insecure).
-- selector: (Optional) A function that returns mongo selector that will limit the results published (or just the selector).
+- collection: A function that returns the collection to publish (or just a collection, if it's insecure). If you've defined `serverArgs` in the settings, `serverArgs` will passed as the first parameter.
+- selector: (Optional) A function that returns mongo selector that will limit the results published (or just the selector). If you've defined `serverArgs` in the settings, `serverArgs` will passed as the first parameter.
 - settings: (Optional) A object with settings on server side's publish function. (Details below)
 
 Inside the functions, `this` is the publish handler object as in [Meteor.publish](http://docs.meteor.com/#/full/meteor_publish), so `this.userId` is available.
@@ -406,7 +407,7 @@ if (Meteor.isServer) {
   ReactiveTable.publish("some-items", Items, {"show": true});
 
   // Publish only to logged in users
-  ReactiveTable.publish("all-items", function () {
+  ReactiveTable.publish("all-items", function (serverArgs) {
     if (this.userId) {
       return Items;
     } else {
@@ -415,7 +416,7 @@ if (Meteor.isServer) {
   });
 
   // Publish only the current user's items
-  ReactiveTable.publish("user-items", Items, function () {
+  ReactiveTable.publish("user-items", Items, function (serverArgs) {
     return {"userId": this.userId};
   });
 }

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -60,6 +60,13 @@ var updateHandle = function (set_context) {
         var onError = function (error) {
             console.log("ReactiveTable subscription error: " + error);
         };
+        if(context.serverArgs) {
+          if(_.isFunction(context.serverArgs)) {
+            var serverArgs = context.serverArgs.call(this);
+          } else {
+            var serverArgs = context.serverArgs;
+          }
+        }
         newHandle = Meteor.subscribe(
             "reactive-table-" + context.collection,
             publicationId,
@@ -67,6 +74,7 @@ var updateHandle = function (set_context) {
             getFilterFields(filters, context.fields),
             options,
             context.rowsPerPage.get(),
+            serverArgs,
             {onReady: onReady, onError: onError}
         );
     }
@@ -149,6 +157,7 @@ var setup = function () {
         }
     }
     context.collection = collection;
+    context.serverArgs = this.data.serverArgs || this.data.settings.serverArgs;
 
     context.multiColumnSort = getDefaultTrueSetting('multiColumnSort', this.data);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 ReactiveTable = {};
 
 ReactiveTable.publish = function (name, collectionOrFunction, selectorOrFunction, settings) {
-    Meteor.publish("reactive-table-" + name, function (publicationId, filters, fields, options, rowsPerPage) {
+    Meteor.publish("reactive-table-" + name, function (publicationId, filters, fields, options, rowsPerPage, serverArgs) {
       check(publicationId, String);
       check(filters, [Match.OneOf(String, Object)]);
       check(fields, [[String]]);
@@ -10,9 +10,9 @@ ReactiveTable.publish = function (name, collectionOrFunction, selectorOrFunction
 
       var collection;
       var selector;
-      
+
       if (_.isFunction(collectionOrFunction)) {
-        collection = collectionOrFunction.call(this);
+        collection = collectionOrFunction.call(this, serverArgs);
       } else {
         collection = collectionOrFunction;
       }
@@ -23,7 +23,7 @@ ReactiveTable.publish = function (name, collectionOrFunction, selectorOrFunction
       }
 
       if (_.isFunction(selectorOrFunction)) {
-        selector = selectorOrFunction.call(this);
+        selector = selectorOrFunction.call(this, serverArgs);
       } else {
         selector = selectorOrFunction;
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ ReactiveTable.publish = function (name, collectionOrFunction, selectorOrFunction
       check(fields, [[String]]);
       check(options, {skip: Match.Integer, limit: Match.Integer, sort: Object});
       check(rowsPerPage, Match.Integer);
+      check(serverArgs, Match.Optional(Match.Any));
 
       var collection;
       var selector;


### PR DESCRIPTION
You can now define a `serverArgs` property in the settings. If
`serverArgs` is a function, it will be executed before passing it to
the publication.

`serverArgs` will be passed as a parameter to `collection` and
`selector` functions of `ReactiveTable.publish`