### PR TITLE
Prevent text selection in table header when toggling sort order

### DIFF
--- a/lib/reactive_table.css
+++ b/lib/reactive_table.css
@@ -17,6 +17,10 @@
 
 .reactive-table .sortable, .reactive-table-add-column {
     cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .table > thead > tr > th.reactive-table-add-column {


### PR DESCRIPTION
Prevent the text selection that occurs when rapidly toggling sort order.