### PR TITLE
Label templates should not require data

### DIFF
--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -23,7 +23,7 @@
                       <input type="checkbox" data-fieldid="{{fieldId}}">
                     {{/if}}
                     <label>
-                      {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}
+                      {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{else}}{{> label}}{{/with}}{{else}}{{getLabel}}{{/if}}
                     </label>
                   </a></li>
                 {{/unless}}
@@ -41,7 +41,7 @@
               {{#if isVisible}}
                 {{#if isPrimarySortField}}
                   <th class="sortable {{getHeaderClass}}" fieldid="{{getFieldFieldId}}">
-                    {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
+                    {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{else}}{{> label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
                     {{#if isAscending}}
                       {{#if ../useFontAwesome}}
                         <i class="fa fa-sort-asc"></i>
@@ -58,9 +58,9 @@
                   </th>
                 {{else}}
                   {{#if isSortable}}
-                    <th class="{{getHeaderClass}} sortable" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                    <th class="{{getHeaderClass}} sortable" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{else}}{{> label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                   {{else}}
-                    <th class="{{getHeaderClass}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
+                    <th class="{{getHeaderClass}}" fieldid="{{getFieldFieldId}}">{{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{else}}{{> label}}{{/with}}{{else}}{{getLabel}}{{/if}}</th>
                   {{/if}}
                 {{/if}}
               {{/if}}

--- a/test/test_fields.js
+++ b/test/test_fields.js
@@ -150,6 +150,23 @@ Tinytest.add('Fields - label tmpl', function (test) {
   );
 });
 
+Tinytest.add('Fields - label tmpl no data', function (test) {
+  testTable(
+    {
+      collection: rows,
+      settings: {
+        fields: [
+          {key: 'name', label: Template.testFieldsTmplNoData}
+        ]
+      }
+    },
+    function () {
+      test.length($('.reactive-table th'), 1, "one column should be rendered");
+      test.length($('.reactive-table th:first-child span.test').text().trim().match(/^nodata/), 1, "first column label");
+    }
+  );
+});
+
 
 Tinytest.add('Fields - header class string', function (test) {
   testTable(

--- a/test/test_fields_tmpl.html
+++ b/test/test_fields_tmpl.html
@@ -1,3 +1,7 @@
 <template name="testFieldsTmpl">
   <span class="test">{{name}}{{score}}</span>
 </template>
+
+<template name="testFieldsTmplNoData">
+  <span class="test">nodata</span>
+</template>


### PR DESCRIPTION
Fixes #222 

Templates should be allowed to be passed for a column label without requiring `labelData` to be set.

Tests included