### PR TITLE
Add new setting to enable exclusive filters

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -49,6 +49,9 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
   if (settings.enableRegex === undefined) {
     settings.enableRegex = false;
   }
+  if (settings.filtersAreExclusive === undefined) {
+    settings.filtersAreExclusive = false;
+  }
   if (settings.fields) {
     _.each(filterInputs, function (filter, index) {
       if (_.any(settings.fields, function (include) { return include; })) {
@@ -117,7 +120,18 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
       }
     }
   });
-  return queryList.length ? {'$and': queryList} : {};
+
+  var query = {};
+
+  if(queryList.length) {
+    if(settings.filtersAreExclusive) {
+      query['$or'] = queryList;
+    } else {
+      query['$and'] = queryList;
+    }
+  }
+
+  return query;
 };
 
 if (Meteor.isClient) {

--- a/lib/reactive_table.js
+++ b/lib/reactive_table.js
@@ -286,6 +286,7 @@ var setup = function () {
     }
     context.noDataTmpl = this.data.noDataTmpl || this.data.settings.noDataTmpl;
     context.enableRegex = getDefaultFalseSetting('enableRegex', this.data);
+    context.filtersAreExclusive = getDefaultFalseSetting('filtersAreExclusive', this.data);
 
     context.ready = new ReactiveVar(true);
 
@@ -311,7 +312,7 @@ var getRowCount = function () {
         var count = ReactiveTableCounts.findOne(this.publicationId.get());
         return (count ? count.count : 0);
     } else {
-        var filterQuery = getFilterQuery(getFilterStrings(this.filters.get()), getFilterFields(this.filters.get(), this.fields), {enableRegex: this.enableRegex});
+        var filterQuery = getFilterQuery(getFilterStrings(this.filters.get()), getFilterFields(this.filters.get(), this.fields), {enableRegex: this.enableRegex, filtersAreExclusive: this.filtersAreExclusive});
         return this.collection.find(filterQuery).count();
     }
 };
@@ -451,7 +452,7 @@ Template.reactiveTable.helpers({
             var sortByValue = _.all(getSortedFields(this.fields, this.multiColumnSort), function (field) {
                 return field.sortByValue || !field.fn;
             });
-            var filterQuery = getFilterQuery(getFilterStrings(this.filters.get()), getFilterFields(this.filters.get(), this.fields), {enableRegex: this.enableRegex});
+            var filterQuery = getFilterQuery(getFilterStrings(this.filters.get()), getFilterFields(this.filters.get(), this.fields), {enableRegex: this.enableRegex, filtersAreExclusive: this.filtersAreExclusive});
 
             var limit = this.rowsPerPage.get();
             var currentPage = this.currentPage.get();


### PR DESCRIPTION
When creating a data table with multiple filters I need the option to have it use $or rather than $and between all of the filters used.

This was done to create a way for me to filter virtual columns