### PR TITLE
Allow Mongo.ObjectID publication filters

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,7 @@ ReactiveTable = {};
 ReactiveTable.publish = function (name, collectionOrFunction, selectorOrFunction, settings) {
     Meteor.publish("reactive-table-" + name, function (publicationId, filters, fields, options, rowsPerPage) {
       check(publicationId, String);
-      check(filters, [Match.OneOf(String, Object)]);
+      check(filters, [Match.OneOf(String, Object, Mongo.ObjectID)]);
       check(fields, [[String]]);
       check(options, {skip: Match.Integer, limit: Match.Integer, sort: Object});
       check(rowsPerPage, Match.Integer);


### PR DESCRIPTION
For collection created with `idGeneration: 'MONGO'`, this allows to perform filters on the `_id` field of such a collection documents.