### PR TITLE
disable sortable on click if "sortable: false"

### DIFF
--- a/lib/reactive_table.html
+++ b/lib/reactive_table.html
@@ -40,7 +40,7 @@
             {{#each fields}}
               {{#if isVisible}}
                 {{#if isSortKey}}
-                  <th class="sortable {{getHeaderClass}}" fieldid="{{getFieldFieldId}}">
+                  <th class="{{#if isSortable}}sortable {{/if}}{{getHeaderClass}}" fieldid="{{getFieldFieldId}}">
                     {{#if labelIsTemplate}}{{#with labelData}}{{> ../label}}{{/with}}{{else}}{{getLabel}}{{/if}}&nbsp;&nbsp;
                     {{#if isAscending}}
                       {{#if ../useFontAwesome}}


### PR DESCRIPTION
This change disables sortable when clicking on column header  if "sortable: false" is set in the column config. This does not impact the actual sorting and renders sortable usable with sortOrder and SortDirection. This fixes #284.