### PR TITLE
allow filtering on _id

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -55,6 +55,7 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
     settings.filterOperator = "$and";
   }
   if (settings.fields) {
+    settings.fields._id = 1;
     _.each(filterInputs, function (filter, index) {
       if (_.any(settings.fields, function (include) { return include; })) {
         filterFields[index] = _.filter(filterFields[index], function (field) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -55,7 +55,7 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
     settings.filterOperator = "$and";
   }
   if (settings.fields) {
-    settings.fields._id = 1;
+    if (!settings.fields._id) settings.fields._id = 1;
     _.each(filterInputs, function (filter, index) {
       if (_.any(settings.fields, function (include) { return include; })) {
         filterFields[index] = _.filter(filterFields[index], function (field) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -59,11 +59,12 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
       if (_.any(settings.fields, function (include) { return include; })) {
         filterFields[index] = _.filter(filterFields[index], function (field) {
           return _.any(getFieldMatches(field), function (fieldMatch) {
+            // ensure that the _id field is filtered on, even if it is not explicitly mentioned
+            if (fieldMatch === "_id") return true;
             return settings.fields[fieldMatch];
           });
         });
-        // ensure that the _id field is filtered on, even if it is not explicitly mentioned
-        if (filterFields[index].indexOf("_id") === -1) filterFields[index].unshift("_id");
+        
       } else {
         filterFields[index] = _.filter(filterFields[index], function (field) {
           return _.all(getFieldMatches(field), function (fieldMatch) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -64,7 +64,6 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
             return settings.fields[fieldMatch];
           });
         });
-        
       } else {
         filterFields[index] = _.filter(filterFields[index], function (field) {
           return _.all(getFieldMatches(field), function (fieldMatch) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -55,7 +55,7 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
     settings.filterOperator = "$and";
   }
   if (settings.fields) {
-    if (!settings.fields._id) settings.fields._id = 1;
+    if (typeof settings.fields._id === "undefined") settings.fields._id = 1;
     _.each(filterInputs, function (filter, index) {
       if (_.any(settings.fields, function (include) { return include; })) {
         filterFields[index] = _.filter(filterFields[index], function (field) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -63,7 +63,7 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
           });
         });
         // ensure that the _id field is filtered on, even if it is not explicitly mentioned
-				if (filterFields[index].indexOf("_id") === -1) filterFields[index].unshift("_id");
+        if (filterFields[index].indexOf("_id") === -1) filterFields[index].unshift("_id");
       } else {
         filterFields[index] = _.filter(filterFields[index], function (field) {
           return _.all(getFieldMatches(field), function (fieldMatch) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -55,7 +55,6 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
     settings.filterOperator = "$and";
   }
   if (settings.fields) {
-    if (typeof settings.fields._id === "undefined") settings.fields._id = 1;
     _.each(filterInputs, function (filter, index) {
       if (_.any(settings.fields, function (include) { return include; })) {
         filterFields[index] = _.filter(filterFields[index], function (field) {
@@ -63,6 +62,8 @@ getFilterQuery = function (filterInputs, filterFields, settings) {
             return settings.fields[fieldMatch];
           });
         });
+        // ensure that the _id field is filtered on, even if it is not explicitly mentioned
+				if (filterFields[index].indexOf("_id") === -1) filterFields[index].unshift("_id");
       } else {
         filterFields[index] = _.filter(filterFields[index], function (field) {
           return _.all(getFieldMatches(field), function (fieldMatch) {


### PR DESCRIPTION
allow filtering on _id, when only selective fields are being published.
There is no need to check for the existence of settings.fields._id IMO, because anyways we have to set it on.