### PR TITLE
Add 0.5em padding to next/previous page

### DIFF
--- a/lib/reactive_table.css
+++ b/lib/reactive_table.css
@@ -48,6 +48,7 @@
 .reactive-table-navigation .next-page {
     font-size: 130%;
     margin: 0 5px;
+    padding: 0.5em;
 }
 
 .reactive-table-navigation .previous-page.fa,


### PR DESCRIPTION
Closes #454 

Increase usability on mobile devices (tablet/smartphone) by adding a bit of padding to the table navigation buttons. The caret symbols are hard to accurately touch, so adding a small amount of padding provides room for human fingertips.