### PR TITLE
Proper Russian translation

### DIFF
--- a/lib/reactive_table_i18n.js
+++ b/lib/reactive_table_i18n.js
@@ -23,9 +23,9 @@ i18n.map('fr', {
 i18n.map('ru', {
     reactiveTable: {
         filter: 'Фильтр',
-        columns: 'Колонка',
+        columns: 'Колонки',
         show: 'Показать',
-        rowsPerPage: 'линий на странице',
+        rowsPerPage: 'строк на странице',
         page: 'Страница',
         of: 'из'
     }


### PR DESCRIPTION
- Columns: from singular to plural
- Rows: replaced with the right word